### PR TITLE
fix multiple logging binding provided during run

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,7 +45,8 @@ libraryDependencies ++= Seq(
     exclude("org.apache.zookeeper", "zookeeper"),
   "com.101tec" % "zkclient" % "0.4"
     exclude("org.apache.zookeeper", "zookeeper"),
-  "org.apache.curator" % "curator-test" % "2.4.0",
+  "org.apache.curator" % "curator-test" % "2.4.0"
+    exclude("org.slf4j", "slf4j-log4j12"),
   "commons-io" % "commons-io" % "2.4",
   // Logback with slf4j facade
   "ch.qos.logback" % "logback-classic" % "1.1.2",


### PR DESCRIPTION
`./sbt run` command causes the following error

```
[info] Running com.miguno.kafkastorm.storm.KafkaStormDemo 
[error] log4j:WARN No appenders could be found for logger (com.miguno.kafkastorm.zookeeper.ZooKeeperEmbedded).
[error] log4j:WARN Please initialize the log4j system properly.
[error] log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
[error] SLF4J: Class path contains multiple SLF4J bindings.
[error] SLF4J: Found binding in [jar:file:/home/viktortnk/.ivy2/cache/org.slf4j/slf4j-log4j12/jars/slf4j-log4j12-1.6.1.jar!/org/slf4j/impl/StaticLoggerBinder.class]
[error] SLF4J: Found binding in [jar:file:/home/viktortnk/.ivy2/cache/ch.qos.logback/logback-classic/jars/logback-classic-1.1.2.jar!/org/slf4j/impl/StaticLoggerBinder.class]
[error] SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
[error] SLF4J: Actual binding is of type [org.slf4j.impl.Log4jLoggerFactory]
```

excluding slf4j-log4j12 from Curator dependency solves the issue
